### PR TITLE
Use Rails 5.4.2.3 CSRF code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/ruby:2.5.1
+      - image: circleci/ruby:2.5.8
     steps:
       - checkout
       - restore_cache:
@@ -20,6 +20,7 @@ jobs:
       - run:
           name: Install Ruby gems
           command: |
+            gem install bundler
             bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - save_cache:
           key: v1-omniauth-protect-{{ checksum "Gemfile.lock" }}
@@ -44,7 +45,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: circleci/ruby:2.5.1
+      - image: circleci/ruby:2.5.8
     steps:
       - checkout
       - run:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  rf-stylez: ruby/rubocop.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2020-06-16
+### Changed
+- Use Rails' 5.2.4.3 CSRF token algorithm

--- a/lib/omniauth/protect.rb
+++ b/lib/omniauth/protect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'rack'
 
@@ -8,7 +10,7 @@ module Omniauth
 
     @config = {
       message: '',
-      paths: []
+      paths: [],
     }
 
     def self.config

--- a/lib/omniauth/protect.rb
+++ b/lib/omniauth/protect.rb
@@ -29,4 +29,5 @@ module Omniauth
   end
 end
 
+require 'omniauth/protect/validator'
 require 'omniauth/protect/middleware'

--- a/lib/omniauth/protect/middleware.rb
+++ b/lib/omniauth/protect/middleware.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require 'omniauth/protect/validator'
+
 module Omniauth
   module Protect
     class Middleware
@@ -17,69 +21,8 @@ module Omniauth
 
           return access_denied if !encoded_masked_token
 
-          valid_csrf_token?(env, encoded_masked_token) ? @app.call(env) : access_denied
+          Validator.new(env, encoded_masked_token).valid_csrf_token? ? @app.call(env) : access_denied
         end
-      end
-
-      def valid_csrf_token?(env, encoded_masked_token)
-        begin
-          masked_token = Base64.urlsafe_decode64(encoded_masked_token)
-        rescue ArgumentError # encoded_masked_token is invalid Base64
-          return false
-        end
-
-        session = session(env)
-
-        token_length = ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH
-
-        if masked_token.length == token_length * 2
-          csrf_token = unmask_token(masked_token, token_length)
-
-          real_token = real_csrf_token(session, token_length)
-          global_token = global_csrf_token(real_token)
-
-          compare_tokens(csrf_token, real_token) || compare_tokens(csrf_token, global_token)
-        end
-      end
-
-      private
-
-      def compare_tokens(token, other)
-        ActiveSupport::SecurityUtils.fixed_length_secure_compare(token, other)
-      end
-
-      def unmask_token(masked_token, token_length)
-        one_time_pad = masked_token[0...token_length]
-        encrypted_csrf_token = masked_token[token_length..-1]
-        xor_byte_strings(one_time_pad, encrypted_csrf_token)
-      end
-
-      def xor_byte_strings(s1, s2) # :doc:
-        s2 = s2.dup
-        size = s1.bytesize
-        i = 0
-        while i < size
-          s2.setbyte(i, s1.getbyte(i) ^ s2.getbyte(i))
-          i += 1
-        end
-        s2
-      end
-
-      def real_csrf_token(session, token_length)
-        session[:_csrf_token] ||= SecureRandom.urlsafe_base64(token_length, padding: false)
-        Base64.urlsafe_decode64(session[:_csrf_token])
-      end
-
-      def global_csrf_token(real_token)
-        OpenSSL::HMAC.digest(
-          OpenSSL::Digest::SHA256.new,
-          real_token,
-          '!real_csrf_token'
-        )
-      end
-
-      def session(env)
-        env['rack.session']
       end
     end
   end

--- a/lib/omniauth/protect/middleware.rb
+++ b/lib/omniauth/protect/middleware.rb
@@ -20,24 +20,62 @@ module Omniauth
           valid_csrf_token?(env, encoded_masked_token) ? @app.call(env) : access_denied
         end
       end
-      # This is mostly taken & adapted from https://github.com/rails/rails/blob/v4.2.0/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L276
+
       def valid_csrf_token?(env, encoded_masked_token)
         begin
-          masked_token = Base64.strict_decode64(encoded_masked_token)
+          masked_token = Base64.urlsafe_decode64(encoded_masked_token)
         rescue ArgumentError # encoded_masked_token is invalid Base64
           return false
         end
 
+        session = session(env)
+
         token_length = ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH
+
         if masked_token.length == token_length * 2
-          one_time_pad = masked_token[0...token_length]
-          encrypted_csrf_token = masked_token[token_length..-1]
-          csrf_token = one_time_pad.bytes.zip(encrypted_csrf_token.bytes).map { |(c1, c2)| c1 ^ c2 }.pack('c*')
-          session = session(env)
-          session[:_csrf_token] ||= SecureRandom.base64(token_length)
-          real_csrf_token = Base64.strict_decode64(session[:_csrf_token])
-          ActiveSupport::SecurityUtils.secure_compare(csrf_token, real_csrf_token)
+          csrf_token = unmask_token(masked_token, token_length)
+
+          real_token = real_csrf_token(session, token_length)
+          global_token = global_csrf_token(real_token)
+
+          compare_tokens(csrf_token, real_token) || compare_tokens(csrf_token, global_token)
         end
+      end
+
+      private
+
+      def compare_tokens(token, other)
+        ActiveSupport::SecurityUtils.fixed_length_secure_compare(token, other)
+      end
+
+      def unmask_token(masked_token, token_length)
+        one_time_pad = masked_token[0...token_length]
+        encrypted_csrf_token = masked_token[token_length..-1]
+        xor_byte_strings(one_time_pad, encrypted_csrf_token)
+      end
+
+      def xor_byte_strings(s1, s2) # :doc:
+        s2 = s2.dup
+        size = s1.bytesize
+        i = 0
+        while i < size
+          s2.setbyte(i, s1.getbyte(i) ^ s2.getbyte(i))
+          i += 1
+        end
+        s2
+      end
+
+      def real_csrf_token(session, token_length)
+        session[:_csrf_token] ||= SecureRandom.urlsafe_base64(token_length, padding: false)
+        Base64.urlsafe_decode64(session[:_csrf_token])
+      end
+
+      def global_csrf_token(real_token)
+        OpenSSL::HMAC.digest(
+          OpenSSL::Digest::SHA256.new,
+          real_token,
+          '!real_csrf_token'
+        )
       end
 
       def session(env)

--- a/lib/omniauth/protect/validator.rb
+++ b/lib/omniauth/protect/validator.rb
@@ -8,6 +8,8 @@ module Omniauth
         @encoded_masked_token = encoded_masked_token
       end
 
+      # This is mostly taken & adapted from Rails' action_controller/metal/request_forgery_protection.rb
+      # We copy code from Rails in such a horrible manner because Rails doesn't really expose CSRF protection
       def valid_csrf_token?
         begin
           masked_token = Base64.urlsafe_decode64(@encoded_masked_token)

--- a/lib/omniauth/protect/validator.rb
+++ b/lib/omniauth/protect/validator.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Omniauth
+  module Protect
+    class Validator
+      def initialize(env, encoded_masked_token)
+        @session = env['rack.session']
+        @encoded_masked_token = encoded_masked_token
+      end
+
+      def valid_csrf_token?
+        begin
+          masked_token = Base64.urlsafe_decode64(@encoded_masked_token)
+        rescue ArgumentError # @encoded_masked_token is invalid Base64
+          return false
+        end
+
+        token_length = ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH
+
+        if masked_token.length == token_length * 2
+          csrf_token = unmask_token(masked_token, token_length)
+
+          real_token = real_csrf_token(token_length)
+          global_token = global_csrf_token(real_token)
+
+          compare_tokens(csrf_token, real_token) || compare_tokens(csrf_token, global_token)
+        end
+      end
+
+      private
+
+      def compare_tokens(token, other)
+        ActiveSupport::SecurityUtils.fixed_length_secure_compare(token, other)
+      end
+
+      def unmask_token(masked_token, token_length)
+        one_time_pad = masked_token[0...token_length]
+        encrypted_csrf_token = masked_token[token_length..-1]
+        xor_byte_strings(one_time_pad, encrypted_csrf_token)
+      end
+
+      def xor_byte_strings(s1, s2) # :doc:
+        s2 = s2.dup
+        size = s1.bytesize
+        i = 0
+        while i < size
+          s2.setbyte(i, s1.getbyte(i) ^ s2.getbyte(i))
+          i += 1
+        end
+        s2
+      end
+
+      def real_csrf_token(token_length)
+        @session[:_csrf_token] ||= SecureRandom.urlsafe_base64(token_length, padding: false)
+        Base64.urlsafe_decode64(@session[:_csrf_token])
+      end
+
+      def global_csrf_token(real_token)
+        OpenSSL::HMAC.digest(
+          OpenSSL::Digest::SHA256.new,
+          real_token,
+          '!real_csrf_token'
+        )
+      end
+    end
+  end
+end

--- a/lib/omniauth/protect/version.rb
+++ b/lib/omniauth/protect/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Omniauth
   module Protect
-    VERSION = '1.0.0'
+    VERSION = '2.0.0'
   end
 end

--- a/omniauth-protect.gemspec
+++ b/omniauth-protect.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'actionpack'
+  spec.add_runtime_dependency 'actionpack', '>= 5.2.4.3', '< 6'
   spec.add_runtime_dependency 'rack'
 
-  spec.add_development_dependency "bundler", '~> 1.10'
+  spec.add_development_dependency "bundler", '~> 2'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'byebug'

--- a/spec/omniauth/middleware_spec.rb
+++ b/spec/omniauth/middleware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'omniauth/protect/middleware'
 
 RSpec.describe Omniauth::Protect::Middleware do
@@ -24,7 +26,7 @@ RSpec.describe Omniauth::Protect::Middleware do
     context '/auth/github' do
       context 'renders 200' do
         it 'valid csrf' do
-          allow_any_instance_of(described_class).to receive(:valid_csrf_token?).and_return(true)
+          allow_any_instance_of(Omniauth::Protect::Validator).to receive(:valid_csrf_token?).and_return(true)
           result = middleware.call(mock_env)
 
           expect(result[0]).to eq 200

--- a/spec/omniauth/protect_spec.rb
+++ b/spec/omniauth/protect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Omniauth::Protect do
   it 'has a version number' do
     expect(Omniauth::Protect::VERSION).not_to be nil
@@ -11,9 +13,9 @@ RSpec.describe Omniauth::Protect do
     expect(Omniauth::Protect.config).to eq(
       {
         message: 'Custom CSRF message',
-        paths: ['/auth/twitter', '/auth/google', '/auth/twitter/', '/auth/google/']
+        paths: ['/auth/twitter', '/auth/google', '/auth/twitter/', '/auth/google/'],
       }
-      )
+    )
   end
 
   context 'exceptions' do
@@ -24,16 +26,16 @@ RSpec.describe Omniauth::Protect do
 
     it 'raises on empty message' do
       Omniauth::Protect.config[:paths] = ['/auth/twitter', '/auth/google']
-      expect{
+      expect do
         Omniauth::Protect.configure
-      }.to raise_exception(Omniauth::Protect::ConfigException, 'message must be specified')
+      end.to raise_exception(Omniauth::Protect::ConfigException, 'message must be specified')
     end
 
     it 'raises on empty paths' do
       Omniauth::Protect.config[:message] = 'Custom CSRF message'
-      expect{
+      expect do
         Omniauth::Protect.configure
-      }.to raise_exception(Omniauth::Protect::ConfigException, 'paths must be specified')
+      end.to raise_exception(Omniauth::Protect::ConfigException, 'paths must be specified')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
-require "bundler/setup"
-require "omniauth/protect"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'omniauth/protect'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
Uses CSRF protection from Rails 5.2.4.3.

Also adds `Omniauth::Protect::Validator` so that it can be used in apps that use that gem for other CSRF validation cases (Grape for example _wink wink_)

Also rubocop

I'm going to release a `3.0.0` version as well for Rails 6+.