### PR TITLE
Update Rails dependency to Rails 6.0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2020-06-25
+### Change
+- Only supports Rails 6+, use 2.0.0 for Rails 5.2.4.3
+
 ## [2.0.0] - 2020-06-16
 ### Changed
 - Use Rails' 5.2.4.3 CSRF token algorithm

--- a/README.md
+++ b/README.md
@@ -20,11 +20,25 @@ Or install it yourself as:
 
 ## Usage
 
-Add this line to your `config/application.rb`
+Add this line to your `config/application.rb` to use the middleware
 
 ```ruby
 config.middleware.use Omniauth::Protect::Middleware
 ```
+
+Or use the validator on it's own
+
+```ruby
+Omniauth::Protect::Validator.new(request.env, encoded_masked_token).valid_csrf_token?
+```
+
+### Rails versions support
+
+`omniauth-protect` `1.0.0` supports `rails < 5.2.4.3` and between `6.0.0` and `6.0.3`
+
+`omniauth-protect` `2.0.0` supports `rails = 5.2.4.3`
+
+`omniauth-protect` `3.0.0` supports `rails > 6.0.3.1`
 
 ## Configuration
 

--- a/lib/omniauth/protect/version.rb
+++ b/lib/omniauth/protect/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Protect
-    VERSION = '2.0.0'
+    VERSION = '3.0.0'
   end
 end

--- a/omniauth-protect.gemspec
+++ b/omniauth-protect.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'actionpack', '>= 5.2.4.3', '< 6'
+  spec.add_runtime_dependency 'actionpack', '>= 6.0.3.1'
   spec.add_runtime_dependency 'rack'
 
   spec.add_development_dependency "bundler", '~> 2'


### PR DESCRIPTION
Because we can't have one version that supports following constraints:
- rails >= 5.2.4.3
- rails < 6
- rails >= 6.0.3.1