### PR TITLE
RF-18632 handle tokens that were cast to a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2020-06-29
+### Fixed
+- Always cast tokens read from session to a string
+
 ## [3.0.0] - 2020-06-25
 ### Change
 - Only supports Rails 6+, use 2.0.0 for Rails 5.2.4.3

--- a/lib/omniauth/protect/middleware.rb
+++ b/lib/omniauth/protect/middleware.rb
@@ -17,7 +17,7 @@ module Omniauth
           return access_denied if env['REQUEST_METHOD'] != 'POST'
 
           req = Rack::Request.new(env)
-          encoded_masked_token = req.params['authenticity_token']
+          encoded_masked_token = req.params['authenticity_token'].to_s
 
           return access_denied if !encoded_masked_token
 

--- a/lib/omniauth/protect/version.rb
+++ b/lib/omniauth/protect/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Protect
-    VERSION = '3.0.0'
+    VERSION = '3.0.1'
   end
 end

--- a/spec/omniauth/middleware_spec.rb
+++ b/spec/omniauth/middleware_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Omniauth::Protect::Middleware do
           expect(result).to eq [403, { 'Content-Type' => 'text/plain' }, ['CSRF detected, Access Denied']]
         end
       end
+
+      context 'when authenticity token is a Hash somehow' do
+        let(:mock_env) do
+          Rack::MockRequest.env_for(
+            url,
+            'REQUEST_METHOD' => 'POST',
+            params: { 'authenticity_token' => {'inline' => '<%= rm -rf / %>' } }
+          )
+        end
+
+        it 'denies access' do
+          result = middleware.call(mock_env)
+
+          expect(result[0]).to eq 403
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
A well prepared request may cause rails to cast params to a Hash.
Nothing bad happens but base64 decoding fails. Casting to string fixes
that