### PR TITLE
RF-26472 Move to use contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,14 @@ workflows:
       - test:
           context:
             - DockerHub
+            - RubyGems
       - style_check:
           filters:
             branches:
               ignore:
                 - master
           context:
+            - circlemator
             - DockerHub
       - push_to_rubygems:
           filters:
@@ -92,3 +94,4 @@ workflows:
                 - /^v.*/
           context:
             - DockerHub
+            - RubyGems

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/ruby:2.5.8
+      - image: circleci/ruby:2.7.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -48,7 +48,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: circleci/ruby:2.5.8
+      - image: circleci/ruby:2.7.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN


### PR DESCRIPTION
- Use contexts
- Upgrade ruby version to overcome:
```
#!/bin/bash -eo pipefail
gem install bundler
bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3

Fetching bundler-2.4.3.gem
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
	bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.8.224.

Exited with code exit status 1
CircleCI received exit code 1
```